### PR TITLE
pyVerifGUI: switch to simplistic use of pygments instead of custom lexer

### DIFF
--- a/pyVerifGUI/pyVerifGUI/gui/editor/editor.py
+++ b/pyVerifGUI/pyVerifGUI/gui/editor/editor.py
@@ -14,7 +14,7 @@
 from qtpy import QtWidgets, QtGui, QtCore
 import os
 
-from .highlighting import SVHighlighter, YAMLHighlighter
+from .highlighting import Highlighter
 
 
 class Editor(QtWidgets.QWidget):
@@ -121,11 +121,7 @@ class FileTab(QtWidgets.QWidget):
         self.file_text.setText(filename)
 
         suffix = filename.split('.')[-1]
-        if not hasattr(self, "highlighter"):
-            if suffix == "sv" or suffix == "v":
-                self.highlighter = SVHighlighter(self.editor.document())
-            if suffix == "yaml":
-                self.highlighter = YAMLHighlighter(self.editor.document())
+        self.highlighter = Highlighter(self.editor.document(), suffix)
 
         # Only if we are explicitly given a cursor position do we add a marker
         if cursor_position >= 0:

--- a/pyVerifGUI/pyVerifGUI/gui/editor/highlighting.py
+++ b/pyVerifGUI/pyVerifGUI/gui/editor/highlighting.py
@@ -16,179 +16,73 @@ from typing import Union, Sequence
 from collections.abc import Iterable
 from collections import namedtuple
 
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatter import Formatter as pyg_Formatter
 
-class SimpleHighlighter(QtGui.QSyntaxHighlighter):
-    """Base class for implementing simple highlighters"""
-    Rule = namedtuple('Rule', ['fmt', 'pattern'])
-    rules = []
+import time
 
-    def addPatterns(self, fmt: QtGui.QTextCharFormat,
-                    patterns: Union[str, Sequence[str]]):
-        """Adds a list of patterns to the list of rules to be matched against"""
-        if isinstance(patterns, Iterable) and type(patterns) is not str:
-            for pattern in patterns:
-                self.rules.append(
-                    self.Rule(fmt, QtCore.QRegularExpression(pattern)))
-        elif type(patterns) is str:
-            self.rules.append(
-                self.Rule(fmt, QtCore.QRegularExpression(patterns)))
-        else:
-            raise TypeError(
-                f"Pattern passed ({patterns}) is not a string or a list of strings!"
-            )
+def color_converter(color):
+    """Converts hex-style color value to QColor object"""
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    return QtGui.QColor(r, g, b)
+
+class Formatter(pyg_Formatter):
+    def __init__(self):
+        super().__init__()
+        self.data = []
+
+        self.styles = {}
+        for token, style in self.style:
+            format = QtGui.QTextCharFormat()
+
+            if style["color"]:
+                format.setForeground(color_converter(style["color"]))
+            if style["bgcolor"]:
+                format.setBackground(color_converter(style["bgcolor"]))
+            if style["bold"]:
+                format.setFontWeight(QtGui.QFont.Bold)
+            if style["italic"]:
+                format.setFontItalic(True)
+            if style["underline"]:
+                format.setFontUnderline(True)
+            
+            self.styles[str(token)] = format
+
+    def format(self, tokensource, outfile):
+        self.data = []
+
+        offset = 0
+        for ttype, value in tokensource:
+            l = len(value)
+            t = str(ttype)
+            self.data.append((offset, l, t))
+
+            offset += l
+
+class Highlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, parent, language):
+        super().__init__(parent)
+
+        self.formatter = Formatter()
+        self.lexer = get_lexer_by_name(language)
+        self.highlighted = False
 
     def highlightBlock(self, text: str):
-        """Function to highlight given block of text"""
-        for rule in self.rules:
-            match_iterator = rule.pattern.globalMatch(text)
-            while match_iterator.hasNext():
-                match = match_iterator.next()
-                self.setFormat(match.capturedStart(), match.capturedLength(),
-                               rule.fmt)
+        # Only highlight once
+        # TODO ideally there's a way to stream into the lexer
+        if not self.highlighted:
+            highlight(self.document().toPlainText() + '\n', self.lexer, self.formatter)
+            self.highlighted = True
 
-        self.setCurrentBlockState(0)
+        offset = self.currentBlock().position()
+        end = offset + len(text)
 
-
-class SVHighlighter(SimpleHighlighter):
-    """Basic SystemVerilog Syntax Highlighter"""
-    def __init__(self, parent):
-        super().__init__(parent)
-
-        # TODO make this regex cleaner
-        # Variable names
-        name_format = QtGui.QTextCharFormat()
-        name_format.setForeground(QtCore.Qt.blue)
-        # I think I may be abusing regexps here
-        self.addPatterns(
-            name_format,
-            "\\b[A-Za-z][A-Za-z0-9_]+(?=[\\h]*[\\(\\[\\<\\=;,\\|\\\&\\+\\)\\]\\H])"
-        )
-
-        # Keywords
-        # XXX Maybe move these elsewhere?
-        keyword_format = QtGui.QTextCharFormat()
-        keyword_format.setForeground(QtCore.Qt.darkBlue)
-        keyword_format.setFontWeight(QtGui.QFont.Bold)
-        keyword_patterns = [
-            "\\balways\\b",
-            "\\bassign\\b",
-            "\\bcase\\b",
-            "\\bdefault\\b",
-            "\\bdefparam\\b",
-            "\\bedge\\b",
-            "\\belse\\b",
-            "\\bevent\\b",
-            "\\bfor\\b",
-            "\\bforce\\b",
-            "\\bforever\\b",
-            "\\bfunction\\b",
-            "\\bif\\b",
-            "\\bifnone\\b",
-            "\\balways_ff\\b",
-            "\\balways_comb\\b",
-            "\\binitial\\b",
-            "\\bjoin\\b",
-            "\\blarge\\b",
-            "\\bmacromodule\\b",
-            "\\bmodule\\b",
-            "\\bnegedge\\b",
-            "\\bnor\\b",
-            "\\bnot\\b",
-            "\\bor\\b",
-            "\\bparameter\\b",
-            "\\bpmos\\b",
-            "\\bposedge\\b",
-            "\\bprimitive\\b",
-            "\\bpull0\\b",
-            "\\bpullup\\b",
-            "\\bpulldown\\b",
-            "\\brelease\\b",
-            "\\brealtime\\b",
-            "\\brelease\\b",
-            "\\brepeat\\b",
-            "\\brtran\\b",
-            "\\btable\\b",
-            "\\btask\\b",
-            "\\btime\\b",
-            "\\btran\\b",
-            "\\bvectored\\b",
-            "\\bwait\\b",
-            "\\bwand\\b",
-            "\\bwhile\\b",
-            "\\bpackage\\b",
-            "\\bendpackage\\b",
-            "\\bendcase\\b",
-            "\\bendmodule\\b",
-            "\\bendfunction\\b",
-            "\\bendprimitive\\b",
-            "\\bendspecify\\b",
-            "\\bendtable\\b",
-            "\\bendtask\\b",
-            "\\bgenerate\\b",
-            "\\bendgenerate\\b",
-        ]
-        self.addPatterns(keyword_format, keyword_patterns)
-
-        # variable types
-        var_format = QtGui.QTextCharFormat()
-        var_format.setForeground(QtCore.Qt.darkRed)
-        var_format.setFontWeight(QtGui.QFont.Bold)
-        var_patterns = [
-            "\\blogic\\b", "\\bwire\\b", "\\binteger\\b", "\\blocalparam\\b",
-            "\\breal\\b", "\\breg\\b", "\\btrireg\\b"
-        ]
-        self.addPatterns(var_format, var_patterns)
-
-        # input, output, inout
-        io_format = QtGui.QTextCharFormat()
-        io_format.setForeground(QtCore.Qt.darkMagenta)
-        io_format.setFontWeight(QtGui.QFont.Bold)
-        io_patterns = ["\\binput\\b", "\\boutput\\b", "\\binout\\b"]
-        self.addPatterns(io_format, io_patterns)
-
-        # Module connections
-        module_conn_format = QtGui.QTextCharFormat()
-        module_conn_format.setForeground(QtCore.Qt.darkRed)
-        self.addPatterns(module_conn_format, "\\.[A-Za-z0-9_]+")
-
-        # "Begin", and "end" should be different than most keywords
-        block_format = QtGui.QTextCharFormat()
-        block_format.setForeground(QtCore.Qt.darkCyan)
-        block_patterns = ["\\bbegin\\b", "\\bend\\b"]
-        self.addPatterns(block_format, block_patterns)
-
-        comment_format = QtGui.QTextCharFormat()
-        comment_format.setForeground(QtCore.Qt.darkGreen)
-        self.addPatterns(comment_format, ["//[^\n]*", "/\*.*/"])
-
-        # Compiler directives
-        compiler_format = QtGui.QTextCharFormat()
-        compiler_format.setForeground(QtCore.Qt.darkMagenta)
-        compiler_format.setFontWeight(QtGui.QFont.Bold)
-        self.addPatterns(compiler_format, "`[A-Za-z]+\\b")
-
-
-class YAMLHighlighter(SimpleHighlighter):
-    """Does some simple YAML highlighting"""
-    def __init__(self, parent):
-        super().__init__(parent)
-
-        bool_format = QtGui.QTextCharFormat()
-        bool_format.setForeground(QtCore.Qt.darkMagenta)
-        self.addPatterns(bool_format, ["\\btrue\\b", "\\bfalse\\b"])
-
-        tag_format = QtGui.QTextCharFormat()
-        tag_format.setForeground(QtCore.Qt.blue)
-        self.addPatterns(tag_format, "\\b[A-Za-z0-9_]+(?=\\:)")
-
-        num_format = QtGui.QTextCharFormat()
-        num_format.setForeground(QtCore.Qt.darkCyan)
-        self.addPatterns(num_format, "\\b[0-9\\.]+")
-
-        str_format = QtGui.QTextCharFormat()
-        str_format.setForeground(QtCore.Qt.darkRed)
-        self.addPatterns(str_format, "\".*\"")
-
-        comment_format = QtGui.QTextCharFormat()
-        comment_format.setForeground(QtCore.Qt.darkGreen)
-        self.addPatterns(comment_format, "\\#[^\n]*")
+        # Only highlight in the current block
+        # TODO doesn't seem to highlight lots of objects.
+        #      is that the lexer or is that something I'm doing wrong?
+        for h in self.formatter.data:
+            if h[0] > offset and h[0] < end:
+                self.setFormat(h[0] - offset, h[1], self.formatter.styles[h[2]])

--- a/pyVerifGUI/requirements.txt
+++ b/pyVerifGUI/requirements.txt
@@ -7,3 +7,4 @@ psutil
 pyside2
 qtpy
 rSVParser
+pygments


### PR DESCRIPTION
This would switch from using a custom highlighter to one based on [pygments](https://pygments.org). It lets me be more flexible, I don't have to write a new highlighter for every language, but I don't particularly like the style it uses for SystemVerilog, which is unfortunate.